### PR TITLE
Improve formatting

### DIFF
--- a/cad_normattiva.py
+++ b/cad_normattiva.py
@@ -95,8 +95,7 @@ def parse_articolo(a):
             break
     intro = lines[:i]
     art, headline, *body = lines[i:]
-    art=re.sub(r"\.$","",art)
-    #title = art + ". " + headline.strip("().")
+    art = re.sub(r"\.$", "", art)
     title = art + " " + headline
     txt_lines = [title, "^" * len(title), ""] + body + ["\n"]
     txt_intro = fix_accent("\n\n".join(intro + ["\n"])) if i else None

--- a/cad_normattiva.py
+++ b/cad_normattiva.py
@@ -71,8 +71,10 @@ def parse_articolo(a):
     # Ignore lines made of dashes
     lines = [re_dashes.sub("\n", l) for l in lines]
 
-    # Removes parentheses from BOL / EOL
-    lines = [re.sub(r"^\(\(|\)\)$", "", l.strip(" ")) for l in lines]
+    #log.debug(lines)
+    ## Removes parentheses
+    #lines = [re.sub(r"\(\((.+?)\)\)", r"\1", l.strip(" ")) for l in lines]
+    #log.debug(lines)
 
     # Insert \n at the end of a numbered list.
     j = 1
@@ -97,9 +99,11 @@ def parse_articolo(a):
             break
     intro = lines[:i]
     art, headline, *body = lines[i:]
-    title = art + ". " + headline.strip("().")
+    art=re.sub(r"\.$","",art)
+    #title = art + ". " + headline.strip("().")
+    title = art + " " + headline
     txt_lines = [title, "^" * len(title), ""] + body + ["\n"]
-    txt_intro = fix_accent("\n".join(intro + ["\n"])) if i else None
+    txt_intro = fix_accent("\n\n".join(intro + ["\n"])) if i else None
     txt_lines = fix_accent("\n".join(txt_lines))
 
     if not txt_intro:

--- a/cad_normattiva.py
+++ b/cad_normattiva.py
@@ -71,10 +71,6 @@ def parse_articolo(a):
     # Ignore lines made of dashes
     lines = [re_dashes.sub("\n", l) for l in lines]
 
-    #log.debug(lines)
-    ## Removes parentheses
-    #lines = [re.sub(r"\(\((.+?)\)\)", r"\1", l.strip(" ")) for l in lines]
-    #log.debug(lines)
 
     # Insert \n at the end of a numbered list.
     j = 1


### PR DESCRIPTION
Avoid repeated newlines
Don't remove double parenthesis (too error prone)
Avoid double dots at the end of the article number
